### PR TITLE
Fix race condition on chekcout progress thread initialization

### DIFF
--- a/cpp/Osmosis/Client/CheckOutProgress.h
+++ b/cpp/Osmosis/Client/CheckOutProgress.h
@@ -19,7 +19,8 @@ public:
 		_path( path ),
 		_digestDirectory( digestDirectory ),
 		_reportIntervalSeconds( reportIntervalSeconds ),
-		_fetchFiles( NULL )
+		_fetchFiles( NULL ),
+		_preWaitStopCondition( false )
 	{
 		_thread = std::thread( & CheckOutProgress::threadEntryPoint, this );
 	}
@@ -34,6 +35,9 @@ public:
 		if ( ! _thread.joinable() )
 			return;
 		_stop.notify_one();
+		_preWaitStopLock.lock();
+		_preWaitStopCondition = true;
+		_preWaitStopLock.unlock();
 		_thread.join();
 		report( true );
 	}
@@ -52,9 +56,16 @@ private:
 	std::thread                    _thread;
 	std::mutex                     _stopLock;
 	std::condition_variable        _stop;
+	std::mutex                     _preWaitStopLock;
+	bool                           _preWaitStopCondition;
 
 	bool sleep()
 	{
+		_preWaitStopLock.lock();
+		if ( _preWaitStopCondition ) {
+			return false;
+		}
+		_preWaitStopLock.unlock();
 		std::unique_lock< std::mutex > lock( _stopLock );
 		auto result = _stop.wait_for( lock, std::chrono::seconds( _reportIntervalSeconds ) );
 		return result == std::cv_status::timeout;


### PR DESCRIPTION
The current implementation of the waiting for the CheckOutProgress and CheckInProgress threads to finish, causes a race condition, which can lead to Osmosis not finishing forever); The `stop` method of `CheckOutProgress` (which is supposed to be called by someone other than the thread itself, who wants to stop the thread) calls `notify_one` on the 'stop' condition variable, which is used by the `CheckOutProgress` thread to wait for a stop command.
But, In case that the checkout was really short in duration, then the `CheckOutThread` hasn't started waiting on the condition variable, which means that `notify_on` has no effect at all. `notify_one` only works when it is invoked -after- someone has started waiting on the condition variable, and not  before (i was supprised too. here is someone with the same problem: http://stackoverflow.com/questions/18691966/are-there-alternative-ways-to-catch-potentially-missed-signals-with-condition-va).
In case that the `notify_on` was missed, then the waiting on the condition variable will be forever (actually terminated after a timeout period and then started again, in a loop).
