### PR TITLE
Split writing to files to chunks so that large files will be written as well

### DIFF
--- a/cpp/Osmosis/Stream/WriteFile.cpp
+++ b/cpp/Osmosis/Stream/WriteFile.cpp
@@ -13,7 +13,7 @@ WriteFile::WriteFile( const char * filename ) :
 	_offset( 0 )
 {}
 
-void WriteFile::write( size_t offset, const void * data, unsigned length )
+void WriteFile::write( size_t offset, const void * data, const unsigned length )
 {
 	ASSERT( data != nullptr );
 	if ( length == 0 )
@@ -21,14 +21,21 @@ void WriteFile::write( size_t offset, const void * data, unsigned length )
 	if ( offset != _offset )
 		seek( offset );
 
-	ssize_t written = ::write( _descriptor.fd(), data, length );
-	if ( written < 0 )
-		THROW_BOOST_ERRNO_EXCEPTION( errno, "Unable to write to '" << _filename <<
-			"' at offset " << _offset );
-	if ( written != length )
-		THROW( Error, "linux write system call return partial data was written: " <<
-				"expected: " << length << " but only " << written << " was written" );
-	_offset += length;
+	auto nrBytesLeftToWrite = length;
+	unsigned char *datap = (unsigned char *) data;
+	while ( nrBytesLeftToWrite > 0 ) {
+		ssize_t written = ::write( _descriptor.fd(), datap, nrBytesLeftToWrite );
+		if ( written <= 0 )
+			THROW_BOOST_ERRNO_EXCEPTION( errno, "Unable to write to '" << _filename <<
+				"' at offset " << _offset );
+		if ( written != nrBytesLeftToWrite )
+			TRACE_WARNING("While writing to file '" << _filename << "': linux 'write' system call return "
+				"value indicates that partial data was written: " <<
+				"expected: " << nrBytesLeftToWrite << " but only " << written << " was written" );
+		_offset += written;
+		nrBytesLeftToWrite -= written;
+		datap += written;
+	}
 }
 
 

--- a/cpp/Osmosis/Stream/WriteFile.h
+++ b/cpp/Osmosis/Stream/WriteFile.h
@@ -14,7 +14,7 @@ class WriteFile
 public:
 	WriteFile( const char * filename );
 
-	void write( size_t offset, const void * data, unsigned length );
+	void write( size_t offset, const void * data, const unsigned length );
 
 private:
 	const std::string _filename;


### PR DESCRIPTION
The `write` syscall sometimes writes partial data (usually occurres when writing big files with several GB).
@Stratoscale/systegration 
