### PR TITLE
Fix compilation errors in Fedora 28

### DIFF
--- a/cpp/Osmosis/Client/CheckExistingThread.h
+++ b/cpp/Osmosis/Client/CheckExistingThread.h
@@ -59,7 +59,7 @@ private:
 		try {
 			while ( true )
 				work();
-		} catch ( DigestedTaskQueue::NoMoreTasksError ) {
+		} catch ( DigestedTaskQueue::NoMoreTasksError &) {
 			_outputQueue.producerDone();
 			TRACE_DEBUG( "CheckExistingThread done" );
 		}

--- a/cpp/Osmosis/Client/DigestDrafts.h
+++ b/cpp/Osmosis/Client/DigestDrafts.h
@@ -50,7 +50,7 @@ private:
 			try {
 				while ( true )
 					work();
-			} catch ( ToVerifyTaskQueue::NoMoreTasksError ) {
+			} catch ( ToVerifyTaskQueue::NoMoreTasksError &) {
 				_digestedTaskQueue.producerDone();
 				TRACE_DEBUG( "DigestThread done" );
 			}

--- a/cpp/Osmosis/Client/DigestThread.h
+++ b/cpp/Osmosis/Client/DigestThread.h
@@ -58,7 +58,7 @@ private:
 		try {
 			while ( true )
 				work();
-		} catch ( PathTaskQueue::NoMoreTasksError ) {
+		} catch ( PathTaskQueue::NoMoreTasksError &) {
 			_outputQueue.producerDone();
 			TRACE_DEBUG( "DigestThread done" );
 		}

--- a/cpp/Osmosis/Client/PutThread.h
+++ b/cpp/Osmosis/Client/PutThread.h
@@ -41,7 +41,7 @@ private:
 		try {
 			while ( true )
 				work();
-		} catch ( DigestedTaskQueue::NoMoreTasksError ) {
+		} catch ( DigestedTaskQueue::NoMoreTasksError &) {
 			TRACE_DEBUG( "PutThread done" );
 		}
 	}

--- a/cpp/Osmosis/Client/TransferThread.h
+++ b/cpp/Osmosis/Client/TransferThread.h
@@ -48,7 +48,7 @@ private:
 		try {
 			while ( true )
 				work();
-		} catch ( DigestedTaskQueue::NoMoreTasksError ) {
+		} catch ( DigestedTaskQueue::NoMoreTasksError &) {
 			TRACE_DEBUG( "Transfer thread done" );
 		}
 	}

--- a/cpp/Osmosis/cppnetlib.cpp
+++ b/cpp/Osmosis/cppnetlib.cpp
@@ -1,2 +1,3 @@
+#include <boost/asio/io_service.hpp>
 #include "../build/cpp-netlib-0.11.1-final/libs/network/src/client.cpp"
 #include "../build/cpp-netlib-0.11.1-final/libs/network/src/uri/uri.cpp"

--- a/cpp/WhiteboxTests/testtaskqueue.cpp
+++ b/cpp/WhiteboxTests/testtaskqueue.cpp
@@ -25,7 +25,7 @@ void consumer( list< string > * target )
 			string task = tested.get();
 			target->emplace( target->end(), std::move( task ) );
 		}
-	} catch ( Queue::NoMoreTasksError ) {}
+	} catch ( Queue::NoMoreTasksError &) {}
 }
 
 bool assertFound( list< string > & out, string lookingFor )


### PR DESCRIPTION
Osmosis fails to compile in Fedora 28 due to two issues:
1. GCC 8  enforces that exceptions be caught by reference
2. Boost headers are included differently 