### PR TITLE
Fix code convention check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ unittest: build
 	build/cpp/testtaskqueue.bin
 
 check_convention:
-	pep8 py tests --max-line-length=109
+	pycodestyle py tests --max-line-length=109
 
 .PHONY: install_binary
 install_binary:

--- a/cpp/Osmosis/Client/CheckIn.cpp
+++ b/cpp/Osmosis/Client/CheckIn.cpp
@@ -13,10 +13,11 @@ CheckIn::CheckIn(        const boost::filesystem::path &  directory,
 		Chain::ObjectStoreInterface &    objectStore,
 		bool                             md5,
 		const boost::filesystem::path &  progressReport,
-		unsigned                         progressReportIntervalSeconds ) :
+		unsigned                         progressReportIntervalSeconds,
+		bool                             followSymlinks ) :
 	_label( label ),
 	_md5( md5 ),
-	_digestDirectory( directory, md5, _ignores ),
+	_digestDirectory( directory, md5, _ignores, followSymlinks ),
 	_putConnection( objectStore.connect() ),
 	_putQueue( CHECK_EXISTING_THREADS ),
 	_checkInProgress( progressReport, _digestDirectory, _putQueue, progressReportIntervalSeconds )

--- a/cpp/Osmosis/Client/CheckIn.h
+++ b/cpp/Osmosis/Client/CheckIn.h
@@ -18,7 +18,8 @@ public:
 			Chain::ObjectStoreInterface &    objectStore,
 			bool                             md5,
 			const boost::filesystem::path &  progressReport,
-			unsigned                         progressReportIntervalSeconds );
+			unsigned                         progressReportIntervalSeconds,
+			bool                             followSymlinks );
 
 	~CheckIn();
 

--- a/cpp/Osmosis/Client/CheckOut.cpp
+++ b/cpp/Osmosis/Client/CheckOut.cpp
@@ -28,7 +28,7 @@ CheckOut::CheckOut(       const boost::filesystem::path &  directory,
 	_removeUnknownFiles( removeUnknownFiles ),
 	_myUIDandGIDcheckout( myUIDandGIDcheckout ),
 	_ignores( ignores ),
-	_digestDirectory( directory, md5, ignores ),
+	_digestDirectory( directory, md5, ignores, false ),
 	_checkOutProgress( progressReport, _digestDirectory, progressReportIntervalSeconds ),
 	_chainTouch( chainTouch )
 {}

--- a/cpp/Osmosis/FileStatus.cpp
+++ b/cpp/Osmosis/FileStatus.cpp
@@ -41,10 +41,10 @@ const boost::filesystem::path FileStatus::symlink() const
 	return _symlink;
 }
 
-bool FileStatus::syncContent() const
+bool FileStatus::syncContent( bool followSymlinks ) const
 {
 	if ( isDirectory() or isCharacter() or isBlock() or
-			isFIFO() or isSymlink() or isSocket() )
+	     isFIFO() or isSocket() or ( isSymlink() and not followSymlinks ) )
 		return false;
 	ASSERT( isRegular() );
 	return true;

--- a/cpp/Osmosis/FileStatus.h
+++ b/cpp/Osmosis/FileStatus.h
@@ -23,7 +23,7 @@ public:
 
 	const boost::filesystem::path symlink() const;
 
-	bool syncContent() const;
+	bool syncContent( bool followSymlinks = false ) const;
 
 	bool isRegular() const;
 	bool isDirectory() const;

--- a/cpp/Osmosis/ObjectStore/Purge.cpp
+++ b/cpp/Osmosis/ObjectStore/Purge.cpp
@@ -11,10 +11,10 @@ Purge::Purge( Store & store, Labels & labels ):
 	_labels( labels )
 {}
 
-void Purge::purge( boost::filesystem::path & dirToPurge )
+void Purge::purge()
 {
 	BACKTRACE_BEGIN
-	startWithAllObjects( dirToPurge );
+	startWithAllObjects();
 	size_t before = _staleHashes.size();
 	TRACE_INFO( "Found " << before << " objects" );
 	takeOutAllLabels();
@@ -26,10 +26,10 @@ void Purge::purge( boost::filesystem::path & dirToPurge )
 	BACKTRACE_END
 }
 
-void Purge::startWithAllObjects( boost::filesystem::path & dirToPurge )
+void Purge::startWithAllObjects()
 {
 	BACKTRACE_BEGIN
-	for ( auto i = _store.list( dirToPurge ); not i.done(); i.next() )
+	for ( auto i = _store.list(); not i.done(); i.next() )
 		_staleHashes.emplace( * i );
 	BACKTRACE_END
 }

--- a/cpp/Osmosis/ObjectStore/Purge.h
+++ b/cpp/Osmosis/ObjectStore/Purge.h
@@ -2,7 +2,6 @@
 #define __OSMOSIS_OBJECT_STORE_PURGE_H__
 
 #include <unordered_set>
-#include <boost/filesystem.hpp>
 #include "Osmosis/ObjectStore/Labels.h"
 #include "Osmosis/ObjectStore/Store.h"
 
@@ -15,14 +14,14 @@ class Purge
 public:
 	Purge( Store & store, Labels & labels );
 
-	void purge( boost::filesystem::path & dirToPurge );
+	void purge();
 
 private:
 	Store &                     _store;
 	Labels &                    _labels;
 	std::unordered_set< Hash >  _staleHashes;
 
-	void startWithAllObjects( boost::filesystem::path & dirToPurge );
+	void startWithAllObjects();
 
 	void takeOutAllLabels();
 

--- a/cpp/Osmosis/ObjectStore/Store.cpp
+++ b/cpp/Osmosis/ObjectStore/Store.cpp
@@ -68,12 +68,6 @@ ObjectsIterator Store::list() const
 	return std::move( iterator );
 }
 
-ObjectsIterator Store::list( boost::filesystem::path rootPath ) const
-{
-	ObjectsIterator iterator( rootPath );
-	return std::move( iterator );
-}
-
 boost::filesystem::path Store::absoluteFilename( const Hash & hash ) const
 {
 	return _rootPath / hash.relativeFilename();

--- a/cpp/Osmosis/ObjectStore/Store.h
+++ b/cpp/Osmosis/ObjectStore/Store.h
@@ -25,8 +25,6 @@ public:
 
 	ObjectsIterator list() const;
 
-	ObjectsIterator list( boost::filesystem::path rootDir ) const;
-
 private:
 	boost::filesystem::path _rootPath;
 

--- a/cpp/Osmosis/main.cpp
+++ b/cpp/Osmosis/main.cpp
@@ -1,4 +1,3 @@
-#include <boost/range/iterator_range.hpp>
 #include <boost/program_options.hpp>
 #include "Osmosis/Server/Server.h"
 #include "Osmosis/Server/BroadcastServer.h"
@@ -11,7 +10,6 @@
 #include "Osmosis/ObjectStore/LeastRecentlyUsed.h"
 #include "Osmosis/ObjectStore/Purge.h"
 #include "Osmosis/FilesystemUtils.h"
-#include "Osmosis/Client/Typedefs.h"
 
 std::mutex globalTraceLock;
 
@@ -148,55 +146,13 @@ void eraseLabel( const boost::program_options::variables_map & options )
 	instance.eraseLabel( label );
 }
 
-void purgeDir( unsigned int threadID, boost::filesystem::path  rootPath, Osmosis::Client::PathTaskQueue & tasksQueue )
-{
-	Osmosis::ObjectStore::Store store( rootPath );
-	Osmosis::ObjectStore::Labels labels( rootPath, store );
-	Osmosis::ObjectStore::Purge purge( store, labels );
-	while ( tasksQueue.size() > 0 ) {
-		boost::filesystem::path dirToPurge = tasksQueue.get();
-		TRACE_INFO("Thread #" << threadID << " handling " << dirToPurge );
-		purge.purge( dirToPurge );
-	}
-	TRACE_INFO("Thread #" << threadID << " finished." );
-}
-
 void purge( const boost::program_options::variables_map & options )
 {
 	boost::filesystem::path rootPath( options[ "objectStoreRootPath" ].as< std::string >() );
-	unsigned nrThreads = options[ "nrPurgeThreads" ].as< unsigned >() ;
-
-	std::vector< std::thread > threads;
-	Osmosis::Client::PathTaskQueue purgeTasks( 1 );
-
-	// adding task per dir
-	for(auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator( rootPath ), {})) {
-		if ( entry.path().string().length() == 31) {
-			TRACE_INFO( "Adding a task for " << entry.path() );
-			boost::filesystem::path entryPath( entry.path() );
-			purgeTasks.put( std::move( entryPath ) );
-		}
-	}
-
-
-	// create threads
-	for ( unsigned i = 0; i < nrThreads; ++ i ) {
-		TRACE_INFO("Generating thread " << i << "...");
-
-		threads.push_back( std::thread(
-            purgeDir,
-			i,
-			std::ref( rootPath ),
-			std::ref( purgeTasks )
-			) );
-
-	}
-
-	TRACE_INFO("waiting for purge threads to finish...");
-	for ( auto & i : threads ) {
-		i.join();
-	}
-
+	Osmosis::ObjectStore::Store store( rootPath );
+	Osmosis::ObjectStore::Labels labels( rootPath, store );
+	Osmosis::ObjectStore::Purge purge( store, labels );
+	purge.purge();
 }
 
 void renameLabel( const boost::program_options::variables_map & options )
@@ -341,10 +297,8 @@ int main( int argc, char * argv [] )
 		( "broadcastToLocalhost", "Use this to broadcast to 127.0.0.7" )
 		("timeout", boost::program_options::value< unsigned short >()->default_value( 1000 ),
 			"Timeout in seconds, for the 'whohaslabel' command")
-		("tcpTimeout", boost::program_options::value< unsigned int >()->default_value( 20000 ),
-			"Timeout in milliseconds for actions on TCP sockets")
-		("nrPurgeThreads", boost::program_options::value< unsigned int >()->default_value( 1 ),
-			"Number of threads dedicated for purge");
+		("tcpTimeout", boost::program_options::value< unsigned int >()->default_value( 7000 ),
+			"Timeout in milliseconds for actions on TCP sockets");
 
 	boost::program_options::options_description positionalDescription( "positionals" );
 	positionalDescription.add_options()

--- a/cpp/Osmosis/main.cpp
+++ b/cpp/Osmosis/main.cpp
@@ -50,6 +50,7 @@ void checkIn( const boost::program_options::variables_map & options )
 	const unsigned int tcpTimeout = options[ "tcpTimeout" ].as< unsigned int >();
 	boost::filesystem::path workDir = stripTrailingSlash( options[ "arg1" ].as< std::string >() );
 	std::string label = options[ "arg2" ].as< std::string >();
+	bool followSymlinks = options.count( "followSymlinks" ) > 0;
 	Osmosis::Chain::Chain chain( options[ "objectStores" ].as< std::string >(), false, false, tcpTimeout );
 	if ( chain.count() > 1 )
 		THROW( Error, "--objectStores must contain one object store in a checkin operation" );
@@ -59,7 +60,8 @@ void checkIn( const boost::program_options::variables_map & options )
 	if ( boost::filesystem::exists( draftsPath ) )
 		THROW( Error, "workDir must not contain " << draftsPath );
 
-	Osmosis::Client::CheckIn instance( workDir, label, chain.single(), md5, reportFile, reportIntervalSeconds );
+	Osmosis::Client::CheckIn instance( workDir, label, chain.single(), md5, reportFile,
+                                       reportIntervalSeconds, followSymlinks );
 	instance.go();
 	BACKTRACE_END
 }
@@ -298,7 +300,9 @@ int main( int argc, char * argv [] )
 		("timeout", boost::program_options::value< unsigned short >()->default_value( 1000 ),
 			"Timeout in seconds, for the 'whohaslabel' command")
 		("tcpTimeout", boost::program_options::value< unsigned int >()->default_value( 7000 ),
-			"Timeout in milliseconds for actions on TCP sockets");
+			"Timeout in milliseconds for actions on TCP sockets")
+		( "followSymlinks", "Follow symlinks (use the poinetd file instead of the symlink file) in checkin");
+
 
 	boost::program_options::options_description positionalDescription( "positionals" );
 	positionalDescription.add_options()

--- a/py/osmosis/policy/cleanupleavelast.py
+++ b/py/osmosis/policy/cleanupleavelast.py
@@ -33,6 +33,7 @@ class CleanupLeaveLast:
         if removed:
             objectStore.purge()
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     from osmosis import objectstore

--- a/py/osmosis/policy/disk.py
+++ b/py/osmosis/policy/disk.py
@@ -8,6 +8,6 @@ def dfPercent(location):
     try:
         line = " ".join(output.split("\n")[1:])
         return int(re.split(r"\s+", line)[4].strip("%"))
-    except:
+    except Exception:
         logging.exception("Unable to parse DF output:\n%(output)s", dict(output=output))
         raise

--- a/tests/fakeservers.py
+++ b/tests/fakeservers.py
@@ -40,7 +40,7 @@ class FakeServer(threading.Thread):
             while True:
                 self._conn, peer = self._sock.accept()
                 self._serve()
-        except:
+        except Exception as ex:
             logging.exception("Fake Server")
 
     def readLog(self):

--- a/tests/httpserver.py
+++ b/tests/httpserver.py
@@ -37,7 +37,7 @@ class HttpServer:
             try:
                 sock.connect((self.hostname(), self._port))
                 return
-            except:
+            except Exception:
                 pass
             finally:
                 sock.close()

--- a/tests/main.py
+++ b/tests/main.py
@@ -510,7 +510,7 @@ class Test(unittest.TestCase):
                 self.assertEquals(client.readFile("firstFile"), "123456")
             finally:
                 client.clean()
-        except:
+        except Exception:
             logging.error("Destination server log:\n%(log)s", dict(log=server.readLog()))
             raise
         finally:
@@ -598,7 +598,7 @@ class Test(unittest.TestCase):
         try:
             self.client.transfer("yuvu", server)
             self.client.transfer("yuv", server)
-        except:
+        except Exception:
             logging.error("Destination server log:\n%(log)s", dict(log=server.readLog()))
             raise
         finally:
@@ -685,7 +685,7 @@ class Test(unittest.TestCase):
         try:
             self.client.transfer("yuvu", server)
             self.client.transfer("yuvu2", server)
-        except:
+        except Exception:
             logging.error("Destination server log:\n%(log)s", dict(log=server.readLog()))
             raise
         finally:
@@ -934,6 +934,7 @@ class Test(unittest.TestCase):
             self.assertFalse(True, "Did not timeout when connecting to non-existing objectstore")
         durationInMilliseconds = (after - before) * 1000
         self.assertLess(durationInMilliseconds, timeoutInMilliseconds + 30)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/osmosiswrapper.py
+++ b/tests/osmosiswrapper.py
@@ -344,7 +344,7 @@ class Server:
         try:
             s.connect(tcpEndpoint)
             return True
-        except:
+        except Exception:
             return False
         finally:
             s.close()
@@ -396,7 +396,7 @@ class BroadcastServer:
         try:
             sock.sendto("\xFF\xFF", (address, port))
             return True
-        except:
+        except Exception:
             return False
         finally:
             sock.close()


### PR DESCRIPTION
There are 2 issues with the code convention check ('make check_convention')
that runs as part of the build:
1. The 'pep8' CLI tool is deprecated, and 'pycodestyle' should be used instead.
2. There are some PEP8 errors.

This commit changes the Makefile to use 'pycodestyle' instead of 'pep8',
and fixes the remaining pep8 errors.