### PR TITLE
Bugfix: purge functionality (and unittest) was broken

### DIFF
--- a/cpp/Osmosis/ObjectStore/Purge.cpp
+++ b/cpp/Osmosis/ObjectStore/Purge.cpp
@@ -11,10 +11,10 @@ Purge::Purge( Store & store, Labels & labels ):
 	_labels( labels )
 {}
 
-void Purge::purge( boost::filesystem::path & dirToPurge )
+void Purge::purge()
 {
 	BACKTRACE_BEGIN
-	startWithAllObjects( dirToPurge );
+	startWithAllObjects();
 	size_t before = _staleHashes.size();
 	TRACE_INFO( "Found " << before << " objects" );
 	takeOutAllLabels();
@@ -26,10 +26,10 @@ void Purge::purge( boost::filesystem::path & dirToPurge )
 	BACKTRACE_END
 }
 
-void Purge::startWithAllObjects( boost::filesystem::path & dirToPurge )
+void Purge::startWithAllObjects()
 {
 	BACKTRACE_BEGIN
-	for ( auto i = _store.list( dirToPurge ); not i.done(); i.next() )
+	for ( auto i = _store.list(); not i.done(); i.next() )
 		_staleHashes.emplace( * i );
 	BACKTRACE_END
 }

--- a/cpp/Osmosis/ObjectStore/Purge.h
+++ b/cpp/Osmosis/ObjectStore/Purge.h
@@ -2,7 +2,6 @@
 #define __OSMOSIS_OBJECT_STORE_PURGE_H__
 
 #include <unordered_set>
-#include <boost/filesystem.hpp>
 #include "Osmosis/ObjectStore/Labels.h"
 #include "Osmosis/ObjectStore/Store.h"
 
@@ -15,14 +14,14 @@ class Purge
 public:
 	Purge( Store & store, Labels & labels );
 
-	void purge( boost::filesystem::path & dirToPurge );
+	void purge();
 
 private:
 	Store &                     _store;
 	Labels &                    _labels;
 	std::unordered_set< Hash >  _staleHashes;
 
-	void startWithAllObjects( boost::filesystem::path & dirToPurge );
+	void startWithAllObjects();
 
 	void takeOutAllLabels();
 

--- a/cpp/Osmosis/ObjectStore/Store.cpp
+++ b/cpp/Osmosis/ObjectStore/Store.cpp
@@ -68,12 +68,6 @@ ObjectsIterator Store::list() const
 	return std::move( iterator );
 }
 
-ObjectsIterator Store::list( boost::filesystem::path rootPath ) const
-{
-	ObjectsIterator iterator( rootPath );
-	return std::move( iterator );
-}
-
 boost::filesystem::path Store::absoluteFilename( const Hash & hash ) const
 {
 	return _rootPath / hash.relativeFilename();

--- a/cpp/Osmosis/ObjectStore/Store.h
+++ b/cpp/Osmosis/ObjectStore/Store.h
@@ -25,8 +25,6 @@ public:
 
 	ObjectsIterator list() const;
 
-	ObjectsIterator list( boost::filesystem::path rootDir ) const;
-
 private:
 	boost::filesystem::path _rootPath;
 

--- a/cpp/Osmosis/main.cpp
+++ b/cpp/Osmosis/main.cpp
@@ -1,4 +1,3 @@
-#include <boost/range/iterator_range.hpp>
 #include <boost/program_options.hpp>
 #include "Osmosis/Server/Server.h"
 #include "Osmosis/Server/BroadcastServer.h"
@@ -11,7 +10,6 @@
 #include "Osmosis/ObjectStore/LeastRecentlyUsed.h"
 #include "Osmosis/ObjectStore/Purge.h"
 #include "Osmosis/FilesystemUtils.h"
-#include "Osmosis/Client/Typedefs.h"
 
 std::mutex globalTraceLock;
 
@@ -148,55 +146,13 @@ void eraseLabel( const boost::program_options::variables_map & options )
 	instance.eraseLabel( label );
 }
 
-void purgeDir( unsigned int threadID, boost::filesystem::path  rootPath, Osmosis::Client::PathTaskQueue & tasksQueue )
-{
-	Osmosis::ObjectStore::Store store( rootPath );
-	Osmosis::ObjectStore::Labels labels( rootPath, store );
-	Osmosis::ObjectStore::Purge purge( store, labels );
-	while ( tasksQueue.size() > 0 ) {
-		boost::filesystem::path dirToPurge = tasksQueue.get();
-		TRACE_INFO("Thread #" << threadID << " handling " << dirToPurge );
-		purge.purge( dirToPurge );
-	}
-	TRACE_INFO("Thread #" << threadID << " finished." );
-}
-
 void purge( const boost::program_options::variables_map & options )
 {
 	boost::filesystem::path rootPath( options[ "objectStoreRootPath" ].as< std::string >() );
-	unsigned nrThreads = options[ "nrPurgeThreads" ].as< unsigned >() ;
-
-	std::vector< std::thread > threads;
-	Osmosis::Client::PathTaskQueue purgeTasks( 1 );
-
-	// adding task per dir
-	for(auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator( rootPath ), {})) {
-		if ( entry.path().string().length() == 31) {
-			TRACE_INFO( "Adding a task for " << entry.path() );
-			boost::filesystem::path entryPath( entry.path() );
-			purgeTasks.put( std::move( entryPath ) );
-		}
-	}
-
-
-	// create threads
-	for ( unsigned i = 0; i < nrThreads; ++ i ) {
-		TRACE_INFO("Generating thread " << i << "...");
-
-		threads.push_back( std::thread(
-            purgeDir,
-			i,
-			std::ref( rootPath ),
-			std::ref( purgeTasks )
-			) );
-
-	}
-
-	TRACE_INFO("waiting for purge threads to finish...");
-	for ( auto & i : threads ) {
-		i.join();
-	}
-
+	Osmosis::ObjectStore::Store store( rootPath );
+	Osmosis::ObjectStore::Labels labels( rootPath, store );
+	Osmosis::ObjectStore::Purge purge( store, labels );
+	purge.purge();
 }
 
 void renameLabel( const boost::program_options::variables_map & options )
@@ -341,10 +297,8 @@ int main( int argc, char * argv [] )
 		( "broadcastToLocalhost", "Use this to broadcast to 127.0.0.7" )
 		("timeout", boost::program_options::value< unsigned short >()->default_value( 1000 ),
 			"Timeout in seconds, for the 'whohaslabel' command")
-		("tcpTimeout", boost::program_options::value< unsigned int >()->default_value( 20000 ),
-			"Timeout in milliseconds for actions on TCP sockets")
-		("nrPurgeThreads", boost::program_options::value< unsigned int >()->default_value( 1 ),
-			"Number of threads dedicated for purge");
+		("tcpTimeout", boost::program_options::value< unsigned int >()->default_value( 7000 ),
+			"Timeout in milliseconds for actions on TCP sockets");
 
 	boost::program_options::options_description positionalDescription( "positionals" );
 	positionalDescription.add_options()


### PR DESCRIPTION
This reverts commit fba6b7cd91605a81afd598e5c391e23db4eaca80.
("Divide purge process to threads")

The reverted commit is faulty and breaks purge functionality.